### PR TITLE
Disable Wifi Projection + Fix assistant hang/missing audio.

### DIFF
--- a/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
@@ -110,6 +110,8 @@ public:
     void setBluetoothAdapterType(BluetoothAdapterType value) override;
     std::string getBluetoothRemoteAdapterAddress() const override;
     void setBluetoothRemoteAdapterAddress(const std::string& value) override;
+    bool getWirelessProjectionEnabled() const override;
+    void setWirelessProjectionEnabled(bool value) override;
 
     bool musicAudioChannelEnabled() const override;
     void setMusicAudioChannelEnabled(bool value) override;
@@ -152,6 +154,7 @@ private:
     bool enablePlayerControl_;
     ButtonCodes buttonCodes_;
     BluetoothAdapterType bluetoothAdapterType_;
+    bool wirelessProjectionEnabled_;
     std::string bluetoothRemoteAdapterAddress_;
     bool musicAudioChannelEnabled_;
     bool speechAudiochannelEnabled_;
@@ -194,6 +197,7 @@ private:
 
     static const std::string cBluetoothAdapterTypeKey;
     static const std::string cBluetoothRemoteAdapterAddressKey;
+    static const std::string cBluetoothWirelessProjectionEnabledKey;
 
     static const std::string cInputEnableTouchscreenKey;
     static const std::string cInputEnablePlayerControlKey;

--- a/include/f1x/openauto/autoapp/Configuration/IConfiguration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/IConfiguration.hpp
@@ -114,6 +114,8 @@ public:
     virtual void setBluetoothAdapterType(BluetoothAdapterType value) = 0;
     virtual std::string getBluetoothRemoteAdapterAddress() const = 0;
     virtual void setBluetoothRemoteAdapterAddress(const std::string& value) = 0;
+    virtual bool getWirelessProjectionEnabled() const = 0;
+    virtual void setWirelessProjectionEnabled(bool value) = 0;
 
     virtual bool musicAudioChannelEnabled() const = 0;
     virtual void setMusicAudioChannelEnabled(bool value) = 0;

--- a/src/autoapp/Configuration/Configuration.cpp
+++ b/src/autoapp/Configuration/Configuration.cpp
@@ -66,6 +66,7 @@ const std::string Configuration::cAudioOutputBackendType = "Audio.OutputBackendT
 
 const std::string Configuration::cBluetoothAdapterTypeKey = "Bluetooth.AdapterType";
 const std::string Configuration::cBluetoothRemoteAdapterAddressKey = "Bluetooth.RemoteAdapterAddress";
+const std::string Configuration::cBluetoothWirelessProjectionEnabledKey = "Bluetooth.WirelessProjectionEnabled";
 
 const std::string Configuration::cInputEnableTouchscreenKey = "Input.EnableTouchscreen";
 const std::string Configuration::cInputEnablePlayerControlKey = "Input.EnablePlayerControl";
@@ -136,6 +137,8 @@ void Configuration::load()
 
         bluetoothAdapterType_ = static_cast<BluetoothAdapterType>(iniConfig.get<uint32_t>(cBluetoothAdapterTypeKey,
                                                                                           static_cast<uint32_t>(BluetoothAdapterType::NONE)));
+
+        wirelessProjectionEnabled_ = iniConfig.get<bool>(cBluetoothWirelessProjectionEnabledKey, true);
 
         bluetoothRemoteAdapterAddress_ = iniConfig.get<std::string>(cBluetoothRemoteAdapterAddressKey, "");
         musicAudioChannelEnabled_ = iniConfig.get<bool>(cAudioMusicAudioChannelEnabled, true);
@@ -222,6 +225,7 @@ void Configuration::save()
 
     iniConfig.put<uint32_t>(cBluetoothAdapterTypeKey, static_cast<uint32_t>(bluetoothAdapterType_));
     iniConfig.put<std::string>(cBluetoothRemoteAdapterAddressKey, bluetoothRemoteAdapterAddress_);
+    iniConfig.put<bool>(cBluetoothWirelessProjectionEnabledKey, wirelessProjectionEnabled_);
 
     iniConfig.put<bool>(cAudioMusicAudioChannelEnabled, musicAudioChannelEnabled_);
     iniConfig.put<bool>(cAudioSpeechAudioChannelEnabled, speechAudiochannelEnabled_);
@@ -526,6 +530,14 @@ std::string Configuration::getBluetoothRemoteAdapterAddress() const
 void Configuration::setBluetoothRemoteAdapterAddress(const std::string& value)
 {
     bluetoothRemoteAdapterAddress_ = value;
+}
+
+bool Configuration::getWirelessProjectionEnabled() const {
+    return wirelessProjectionEnabled_;
+}
+
+void Configuration::setWirelessProjectionEnabled(bool value) {
+    wirelessProjectionEnabled_ = value;
 }
 
 bool Configuration::musicAudioChannelEnabled() const

--- a/src/autoapp/Service/AndroidAutoEntity.cpp
+++ b/src/autoapp/Service/AndroidAutoEntity.cpp
@@ -249,7 +249,8 @@ void AndroidAutoEntity::onPingRequest(const aasdk::proto::messages::PingRequest&
 
 void AndroidAutoEntity::onVoiceSessionRequest(const aasdk::proto::messages::VoiceSessionRequest& request)
 {
-	OPENAUTO_LOG(error) << "[AndroidAutoEntity] voice session request not implemented";
+    OPENAUTO_LOG(info) << "[AndroidAutoEntity] onVoiceSessionRequest()";
+    controlServiceChannel_->receive(this->shared_from_this());
 }
 
 void AndroidAutoEntity::onShutdownResponse(const aasdk::proto::messages::ShutdownResponse&)

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -66,9 +66,12 @@ ServiceList ServiceFactory::create(aasdk::messenger::IMessenger::Pointer messeng
     this->createAudioServices(serviceList, messenger);
     serviceList.emplace_back(std::make_shared<SensorService>(ioService_, messenger));
     serviceList.emplace_back(this->createVideoService(messenger));
-    serviceList.emplace_back(this->createBluetoothService(messenger));
+    if (configuration_->getWirelessProjectionEnabled())
+    {
+        serviceList.emplace_back(this->createBluetoothService(messenger));
+        serviceList.emplace_back(std::make_shared<WifiService>(ioService_, messenger, configuration_));
+    }
     serviceList.emplace_back(this->createInputService(messenger));
-    serviceList.emplace_back(std::make_shared<WifiService>(ioService_, messenger, configuration_));
 
     return serviceList;
 }

--- a/src/autoapp/UI/SettingsWindow.cpp
+++ b/src/autoapp/UI/SettingsWindow.cpp
@@ -250,6 +250,12 @@ void SettingsWindow::onSave()
         configuration_->setBluetoothAdapterType(configuration::BluetoothAdapterType::REMOTE);
     }
 
+    if (ui_->disableProjectionButton->isChecked()) {
+        configuration_->setWirelessProjectionEnabled(false);
+    } else {
+        configuration_->setWirelessProjectionEnabled(true);
+    }
+
     configuration_->setBluetoothRemoteAdapterAddress(ui_->lineEditExternalBluetoothAdapterAddress->text().toStdString());
 
     configuration_->setMusicAudioChannelEnabled(ui_->checkBoxMusicAudioChannel->isChecked());
@@ -524,6 +530,7 @@ void SettingsWindow::load()
     ui_->radioButtonUseExternalBluetoothAdapter->setChecked(configuration_->getBluetoothAdapterType() == configuration::BluetoothAdapterType::REMOTE);
     ui_->lineEditExternalBluetoothAdapterAddress->setEnabled(configuration_->getBluetoothAdapterType() == configuration::BluetoothAdapterType::REMOTE);
     ui_->lineEditExternalBluetoothAdapterAddress->setText(QString::fromStdString(configuration_->getBluetoothRemoteAdapterAddress()));
+    ui_->disableProjectionButton->setChecked(!configuration_->getWirelessProjectionEnabled());
 
     ui_->checkBoxMusicAudioChannel->setChecked(configuration_->musicAudioChannelEnabled());
     ui_->checkBoxSpeechAudioChannel->setChecked(configuration_->speechAudioChannelEnabled());

--- a/src/autoapp/UI/settingswindow.ui
+++ b/src/autoapp/UI/settingswindow.ui
@@ -2980,6 +2980,49 @@ outline: none;</string>
        </widget>
       </item>
       <item>
+       <widget class="QGroupBox" name="groupWirelessProjection">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="cursor">
+         <cursorShape>ArrowCursor</cursorShape>
+        </property>
+        <property name="title">
+         <string>Wireless Projection</string>
+        </property>
+        <layout class="QVBoxLayout" name="groupWirelessProjection_layout" stretch="0">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="disableProjectionButton">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Disable Wireless Projection</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="horizontalWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">


### PR DESCRIPTION
* Bonus: Fix assistant hang/missing audio.

* Add new wireless projection config section.
* Add check box to disable/enable wireless projection. Checking this box causes the service factory to skip the bluetooth and wifi services.